### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#GET STARTED
+# GET STARTED
 
 ```
 $ git clone https://github.com/githubjeka/angular-yii2.git
@@ -7,7 +7,7 @@ $ git submodule init
 $ git submodule update
 ```
 
-###Init client###
+### Init client ###
 ```
 $ cd client-angular
 $ bower update
@@ -15,7 +15,7 @@ $ bower update
 
 See more info https://github.com/AngularYii2/angularyii2.github.io
 
-###Init server:###
+### Init server: ###
 
 [![Build Status](https://travis-ci.org/githubjeka/yii2-rest.svg)](https://travis-ci.org/githubjeka/yii2-rest)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
